### PR TITLE
Sette loggdestinasjonar eksplisitt

### DIFF
--- a/obo-kafka-manager/dev/nais.yaml
+++ b/obo-kafka-manager/dev/nais.yaml
@@ -39,6 +39,11 @@ spec:
           - id: 17affa79-5227-4209-89c6-34abb5cc7cc9 # nais-team-obo
   kafka:
     pool: nav-dev
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   env:
     - name: APP_CONFIG_JSON
       value: >

--- a/obo-kafka-manager/prod/nais.yaml
+++ b/obo-kafka-manager/prod/nais.yaml
@@ -39,6 +39,11 @@ spec:
           - id: 17affa79-5227-4209-89c6-34abb5cc7cc9 # nais-team-obo
   kafka:
     pool: nav-prod
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   env:
     - name: APP_CONFIG_JSON
       value: >


### PR DESCRIPTION
[Nais skal/har gått over til Grafana Loki som default loggverktøy og Elastic Kibana er difor deprekert](https://nav-it.slack.com/docs/T5LNAMWNA/F08RNSRJ934). Elastic vil vere tilgjengeleg ut året, så inntil vi får migrert til Grafana Loki, må vi eksplisitt spesifisere Elastic Kibana som loggdestinasjon. Legg difor til både `elastic` og `loki` som loggdestinasjonar slik at vi kan halde fram med å få loggar i Kibana. Når vi er blitt vande nok med Loki kan vi gå over permanent og fjerne `elastic`.